### PR TITLE
Removal of GatherHere sign up email address and replacement with hyperlink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ collections:
     output: true
   faq:
     output: true
-
+google_analytics: UA-139430618-1
 resources_name: "resource-room"
 
 ##################################################################################################################

--- a/_resources/4-gather-here.md
+++ b/_resources/4-gather-here.md
@@ -25,7 +25,7 @@ Government agencies can use GatherHere to conduct research, surveys and analyse 
 Social Service professionals can join the various community groups available in GatherHere to gain insights on the latest trends within the social service sector, join discussions on topics of interest and stay connected to other members of the Social Service Tribe, among other benefits.
 
 ### Join GatherHere    
-If you are interested to join GatherHere, you can drop us an email at [techservices1@gatherhere.sg](mailto:techservices1@gatherhere.sg)
+If you are interested to join GatherHere, you can drop us an email by [clicking here](mailto:techservices1@gatherhere.sg)
 
 SSI also provides a suite of services to facilitate the onboarding process and manage your engagement digitally. The full list of services provided are as shown below.
 - Technical Support and Technology Management


### PR DESCRIPTION
The GatherHere email address does not have gov.sg in it and has to be replaced with a hyperlink to hide it