### PR TITLE
Removal of line in copy that is causing confusion

### DIFF
--- a/_training/12-SGunited-skills-programme.md
+++ b/_training/12-SGunited-skills-programme.md
@@ -10,7 +10,7 @@ permalink: /training/sgus/
 
 The SGUnited skills (SGUS) Programme was launched by DPM Heng Swee Keat on 26 May 2020 to support an estimated 100,000 Singaporeans whose livelihoods have been affected by the COVID-19 pandemic. Through SGUS, job and traineeship opportunities will be provided to jobseekers to help them acquire the skillsets and capabilities needed to access expanded employment opportunities in both the private and public sector.
 
-Over 40,000 jobs will be provided through this ‘Train-and-Place’ model and the courses under SGUS will be rolled out progressively from Jul 2020 till Dec 2020. All courses under the SGUS programme are modularised to be industry-relevant and certifiable and were designed in partnership with employers in the public and private sector. For learners who lack the basic skillsets required to access SGUS courses, bridging modules in basic literacy, numeracy, digital literacy and basic financial planning will be provided.
+Over 40,000 jobs will be provided through this ‘Train-and-Place’ model and all courses under the SGUS programme are modularised to be industry-relevant and certifiable and were designed in partnership with employers in the public and private sector. For learners who lack the basic skillsets required to access SGUS courses, bridging modules in basic literacy, numeracy, digital literacy and basic financial planning will be provided.
 
 ### How Do We Help?
 


### PR DESCRIPTION
The line "... and the courses under SGUS will be rolled out progressively from Jul 2020 till Dec 2020. " has caused confusion among website visitors who think that SSI's programmes will be rolled out from Jul 20 onwards. I have removed it.