### PR TITLE
Change of QSM email

### DIFF
--- a/pages/Privacy Statement.md
+++ b/pages/Privacy Statement.md
@@ -2,43 +2,122 @@
 title: Privacy Statement
 permalink: /privacy/
 description: ""
+variant: tiptap
 ---
-**PRIVACY STATEMENT**
-
-1\. This is a Government of Singapore digital service. 
- 
-2\. We may use "cookies", where a small data file is sent to your browser to store and track information about you when you enter our digital service. The cookie is used to track information such as the number of users and their frequency of use, profiles of users and their preferred digital services. While this cookie can tell us when you enter our digital services and which pages you visit, it cannot read data off your hard disk.  
-
-3\. You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the digital service.  
-
-**Use of Data**
-
-4\. If you provide us with personal data:
-
-   a. Where appropriate, we may share necessary data with other Government Agencies, so as to improve the discharge of public functions, and to serve you in the most efficient and effective way unless such sharing is prohibited by law.
-
-   b. We may share your personal data with non-Government entities that have been authorised to carry out specific Government services. We will NOT share your personal data with other non-Government entities without your consent except where such sharing complies with the law.
-
-   c. For your convenience, we may also display to you data that you had previously supplied us or other Government Agencies. This will speed up the transaction and save you the trouble of repeating previous submissions. Should the data be out-of-date, please supply us the latest data.
-
-**Protection of Data**
-
-5\. To safeguard your personal data, all electronic storage and transmission of personal data is secured with appropriate security technologies.  
-
-6\. This digital service may contain links to non-Government digital services whose data protection and privacy practices may differ from ours.  We are not responsible for the content and privacy practices of these other digital services and we encourage you to consult the privacy notices of those digital services.  
-
-**Contact Information**
-
-7\. Please contact [socialserviceinstitute@qsm.sg](mailto:socialserviceinstitute@qsm.sg) if you:
-
-   a. have any enquires or feedback on our data protection, policies and procedures; or
-
-   b. need more information on or access to data which you have provided directly to us in the past.
-
-**Definitions**
-
-8\. "Government Agency” refers to an Organ of State, Ministry, Department or Statutory Board.
-
-9\. ”Non-Government entity” refers to a person other than a Government Agency.
-
-10\. “Personal data” shall have the same meaning as its definition in the Personal Data Protection Act 2012 (No. 26 of 2012).”
+<p><strong>Privacy Statement</strong>
+</p>
+<ol data-tight="true" class="tight">
+<li>
+<p>This is a Government of Singapore digital service.
+<br>
+</p>
+</li>
+<li>
+<p>We may use "cookies", where a small data file is sent to your browser
+to store and track information about you when you enter our digital service.
+The cookie is used to track information such as the number of users and
+their frequency of use, profiles of users and their preferred digital services.
+While this cookie can tell us when you enter our digital services and which
+pages you visit, it cannot read data off your hard disk.
+<br>
+</p>
+</li>
+<li>
+<p>You can choose to accept or decline cookies. Most web browsers automatically
+accept cookies, but you can usually modify your browser setting to decline
+cookies if you prefer. This may prevent you from taking full advantage
+of the digital service.
+<br>
+<br><strong>Use of Data</strong>
+<br>
+</p>
+</li>
+<li>
+<p>If you provide us with personal data:
+<br>
+</p>
+<ol data-tight="true" class="tight">
+<li>
+<p>Where appropriate, we may share necessary data with other Government Agencies,
+so as to improve the discharge of public functions, and to serve you in
+the most efficient and effective way unless such sharing is prohibited
+by law.
+<br>
+</p>
+</li>
+<li>
+<p>We may share your personal data with non-Government entities that have
+been authorised to carry out specific Government services. We will NOT
+share your personal data with other non-Government entities without your
+consent except where such sharing complies with the law.
+<br>
+</p>
+</li>
+<li>
+<p>For your convenience, we may also display to you data that you had previously
+supplied us or other Government Agencies. This will speed up the transaction
+and save you the trouble of repeating previous submissions. Should the
+data be out-of-date, please supply us the latest data.</p>
+<p></p>
+</li>
+</ol>
+<p><strong>Protection of Data</strong>
+<br>
+</p>
+</li>
+<li>
+<p>To safeguard your personal data, all electronic storage and transmission
+of personal data is secured with appropriate security technologies.
+<br>
+</p>
+</li>
+<li>
+<p>This digital service may contain links to non-Government digital services
+whose data protection and privacy practices may differ from ours. We are
+not responsible for the content and privacy practices of these other digital
+services and we encourage you to consult the privacy notices of those digital
+services.
+<br>
+<br><strong>Contact Information</strong>
+</p>
+<p></p>
+</li>
+<li>
+<p>Please contact <a href="mailto:socialserviceinstitute@ncss.gov.sg" rel="noopener noreferrer nofollow" target="_blank">socialserviceinstitute@ncss.gov.sg</a> if
+you:
+<br>
+</p>
+<ol data-tight="true" class="tight">
+<li>
+<p>have any enquires or feedback on our data protection, policies and procedures;
+or
+<br>
+</p>
+</li>
+<li>
+<p>need more information on or access to data which you have provided directly
+to us in the past.
+<br>
+</p>
+<p><strong>Definitions</strong>
+<br>
+</p>
+</li>
+</ol>
+</li>
+<li>
+<p>"Government Agency” refers to an Organ of State, Ministry, Department
+or Statutory Board.</p>
+<p></p>
+</li>
+<li>
+<p>”Non-Government entity” refers to a person other than a Government Agency.
+<br>
+</p>
+</li>
+<li>
+<p>“Personal data” shall have the same meaning as its definition in the Personal
+Data Protection Act 2012 (No. 26 of 2012).”</p>
+</li>
+</ol>
+<p></p>

--- a/pages/Privacy Statement.md
+++ b/pages/Privacy Statement.md
@@ -4,13 +4,11 @@ permalink: /privacy/
 description: ""
 variant: tiptap
 ---
-<p><strong>Privacy Statement</strong>
-</p>
+<h4><strong>Privacy Statement</strong></h4>
 <ol data-tight="true" class="tight">
 <li>
-<p>This is a Government of Singapore digital service.
-<br>
-</p>
+<p>This is a Government of Singapore digital service.</p>
+<p></p>
 </li>
 <li>
 <p>We may use "cookies", where a small data file is sent to your browser
@@ -20,6 +18,7 @@ their frequency of use, profiles of users and their preferred digital services.
 While this cookie can tell us when you enter our digital services and which
 pages you visit, it cannot read data off your hard disk.
 <br>
+<br>
 </p>
 </li>
 <li>
@@ -28,7 +27,7 @@ accept cookies, but you can usually modify your browser setting to decline
 cookies if you prefer. This may prevent you from taking full advantage
 of the digital service.
 <br>
-<br><strong>Use of Data</strong>
+<br><strong>Use of Data</strong> 
 <br>
 </p>
 </li>
@@ -61,13 +60,14 @@ data be out-of-date, please supply us the latest data.</p>
 <p></p>
 </li>
 </ol>
-<p><strong>Protection of Data</strong>
+<p><strong>Protection of Data</strong> 
 <br>
 </p>
 </li>
 <li>
 <p>To safeguard your personal data, all electronic storage and transmission
 of personal data is secured with appropriate security technologies.
+<br>
 <br>
 </p>
 </li>
@@ -99,7 +99,7 @@ or
 to us in the past.
 <br>
 </p>
-<p><strong>Definitions</strong>
+<p><strong>Definitions</strong> 
 <br>
 </p>
 </li>
@@ -107,8 +107,9 @@ to us in the past.
 </li>
 <li>
 <p>"Government Agency” refers to an Organ of State, Ministry, Department
-or Statutory Board.</p>
-<p></p>
+or Statutory Board.
+<br>
+</p>
 </li>
 <li>
 <p>”Non-Government entity” refers to a person other than a Government Agency.


### PR DESCRIPTION
Pei Qi TAN (NCSS) confirmed that the QSM email on Privacy page should be socialserviceinstitute@ncss.gov.sg instead of  socialserviceinstitute@qsm.sg. 